### PR TITLE
got rid of required_methods for version_4 compatibility

### DIFF
--- a/src/QMDP.jl
+++ b/src/QMDP.jl
@@ -5,7 +5,7 @@ using POMDPToolbox
 using DiscreteValueIteration
 
 import POMDPs: Solver, Policy
-import POMDPs: create_policy, solve, action, value, update, initialize_belief, updater, create_belief, create_policy
+import POMDPs: solve, action, value, update, initialize_belief, updater
 
 export
     QMDPSolver,

--- a/src/required.jl
+++ b/src/required.jl
@@ -1,3 +1,5 @@
+# getting rid of for version_4
+#=
 const REQUIRED_FUNCTIONS = [states,
                             actions,
                             iterator,
@@ -11,3 +13,4 @@ const REQUIRED_FUNCTIONS = [states,
 function required_methods()
     POMDPs.get_methods(REQUIRED_FUNCTIONS)
 end
+=#

--- a/src/vanilla.jl
+++ b/src/vanilla.jl
@@ -50,6 +50,11 @@ create_policy(solver::QMDPSolver, pomdp::POMDP) = QMDPPolicy(pomdp)
 
 updater(p::QMDPPolicy) = DiscreteUpdater(p.pomdp)
 
+@POMDP_require solve(solver::QMDPSolver, pomdp::POMDP) begin
+    vi_solver = ValueIterationSolver(solver.max_iterations, solver.tolerance)
+    @subreq solve(vi_solver, pomdp)
+end
+
 function solve(solver::QMDPSolver, pomdp::POMDP, policy::QMDPPolicy=create_policy(solver, pomdp); verbose::Bool=false)
     vi_solver = ValueIterationSolver(solver.max_iterations, solver.tolerance)
     vi_policy = ValueIterationPolicy(pomdp, include_Q=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using QMDP
+using POMDPs
 using POMDPModels
 using GenerativeModels
 using POMDPToolbox
@@ -6,6 +7,9 @@ using Base.Test
 
 pomdp = TigerPOMDP()
 solver = QMDPSolver()
+
+@requirements_info solver pomdp
+
 policy = solve(solver, pomdp, verbose=true)
 rng = MersenneTwister(11)
 


### PR DESCRIPTION
@etotheipluspi This just makes QMDP compatible with both the current version and the upcoming version 0.4 of POMDPs.jl. You can merge it or I will before POMDPs v0.4 comes out.
