### PR TITLE
Update installation instructions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This Julia package implements the QMDP approximate solver for POMDP/MDP planning
 ## Installation
 
 ```julia
-using POMDPs, Pkg
-POMDPs.add_registry()
+import Pkg
 Pkg.add("QMDP")
 ```
 


### PR DESCRIPTION
The step of adding the POMDPs registry is not necessary anymore (at least not for the new versions).