### PR TITLE
Update tests wrt test_solver use

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,17 +1,34 @@
 name: CI
-
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
 jobs:
   test:
-    runs-on: ubuntu-latest
-
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1"
+          - "1.10" # Julia LTS
+        os:
+          - ubuntu-latest
+          # - macOS-latest
+          # - windows-latest
+        arch:
+          - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
-          arch: x64
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,7 @@ using Random
     show_requirements(get_requirements(POMDPs.solve, (solver, pomdp)))
 
     policy = solve(solver, pomdp)
-
-    solver = QMDPSolver(verbose=false)
+    
     rng = MersenneTwister(11)
 
     bu = updater(policy)
@@ -32,14 +31,37 @@ using Random
     bp = update(bu, b, a, o)
     @test isa(bp, DiscreteBelief)
 
-    r = test_solver(solver, pomdp)
-    @test isapprox(r, 17.711, atol=1e-2)
+    # Functional test for solver
+    solver = QMDPSolver(verbose=false)
+    test_solver(solver, pomdp)
+    
+    solver = QMDPSolver(; verbose=false, max_iterations=1000, belres=1e-10)
+    policy = solve(solver, pomdp)
+    @test length(actions(pomdp)) == length(policy.alphas)
+    
+    known_left_or_right = pomdp.r_escapetiger / (1 - discount(pomdp))
+    # assuming 0.5 * pomdp.r_findtiger + 0.5 * pomdp.r_escapetiger < r_listen 
+    uniform_value = pomdp.r_listen + discount(pomdp) * known_left_or_right
+    
+    @test isapprox(value(policy, BoolDistribution(1.0)), known_left_or_right, atol=1e-3)
+    @test isapprox(value(policy, BoolDistribution(0.0)), known_left_or_right, atol=1e-3)
+    @test isapprox(value(policy, BoolDistribution(0.5)), uniform_value, atol=1e-3)
 end
 
 @testset "Sparse QMDP" begin
     pomdp = TigerPOMDP()
     solver = QMDPSolver(SparseValueIterationSolver())
 
-    r = test_solver(solver, pomdp)
-    @test isapprox(r, 17.711, atol=1e-2)
+    # Functional test for solver
+    test_solver(solver, pomdp)
+    solver = QMDPSolver(SparseValueIterationSolver(; verbose=false, max_iterations=1000, belres=1e-10))
+    policy = solve(solver, pomdp)
+    @test length(actions(pomdp)) == length(policy.alphas)
+    
+    known_left_or_right = pomdp.r_escapetiger / (1 - discount(pomdp))
+    # assuming 0.5 * pomdp.r_findtiger + 0.5 * pomdp.r_escapetiger < r_listen 
+    uniform_value = pomdp.r_listen + discount(pomdp) * known_left_or_right
+    @test isapprox(value(policy, BoolDistribution(1.0)), known_left_or_right, atol=1e-3)
+    @test isapprox(value(policy, BoolDistribution(0.0)), known_left_or_right, atol=1e-3)
+    @test isapprox(value(policy, BoolDistribution(0.5)), uniform_value, atol=1e-3)
 end


### PR DESCRIPTION
Changed from using `test_solver` to compare values for a single simulation after generating the policy to be a functional test.

Added in value tests for the QMDP policy for the Tiger problem based on ease of calculating the value at different beliefs.

Updated CI.